### PR TITLE
Upload to the CDN before publishing to npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,22 @@ branches:
   only:
     - master
 
-# Ready npm publish.
-script: 'yarn build-js'
+script: 'yarn build'
 
 deploy:
+  - provider: script
+    # Prevent Travis from resetting the build artifacts.
+    skip_cleanup: true
+    script: yarn upload -- --use-prebuilt
+    on:
+      tags: true
+      branch: master
   - provider: npm
     email: admin+mixmax-codeship-npm@mixmax.com
     api_key:
       secure: FCj0WT09y+mD5Jc7nadlKEikkUxMw+tFjyAiuJ7FAzrdmg9ijg+k7UyW6f4CTrxESdU+Ta21zFtHAqUyCZs3m5rgHsyA1ln5+qjb92SORn32CPTBbXyaEeWltUWhxCqUdAubZpCxr69XFSXGCoBJyDdKTk/Kxu/FNFTx5348Ld1ln5HMkQaJVaDpjdZgT9mNejoFazXJkdDMbFp3qt5I8c9PSel7RofeMKmkP7tZlytDic7bgO+mMyvpGRdRajFUzSTB+esGZk9uYkigT6AvJoWMBRbJqDEq9PsEsPZPkukipaWJjNtKJRc9Dj+1DhT5yCRLYo/lmAPP4lsPZpIWpSaDqijqBlIUcnnsAUIT9tgZpW/7OPwrWGXWYfixiBT2K3t0A2w6rUxZiQAtqy9Qw04Ih7TGmQBYhSFXO342y1gnURYHuX1pq7b+kbp2xUj7RHKo0KgMx/1DBXpJZWO7Wy6e0A1TTRMXidddNEMhYwyJVc/IjtGg46DTQLJVmrqsHTTxMDokKp94d83Vjz3r3eIuqRpqVevrnDu5MSY44osYqRZK62kvs5fBGmi/qOa2ph1coRxsUAgF4tT88d0jryUSRSODg5udc0BX3Q3lsch9GnH0c4rqVCmzvHbdxNo11UmmgmNpV+AGyCyEgY1XhYkgaslSgqbpkDBUwwBbpsM=
     # Prevent Travis from resetting the build artifacts.
     skip_cleanup: true
-    on:
-      tags: true
-      branch: master
-  - provider: script
-    # Prevent Travis from resetting the build artifacts.
-    skip_cleanup: true
-    script: yarn upload -- --use-prebuilt-js
     on:
       tags: true
       branch: master

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,10 +156,8 @@ gulp.task('build-assets', function() {
 
 gulp.task('build', function(done) {
   let tasks = [];
-  if (argv['use-prebuilt-js']) {
-    // If the JS was prebuilt, we shouldn't clean, and only need to build the assets.
-    tasks.push('build-assets');
-  } else {
+  if (!argv['use-prebuilt']) {
+    // If we've built already, we don't need to do anything.
     tasks.push('clean', ['build-js', 'build-assets']);
   }
   runSequence(...tasks, done);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "start": "gulp",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build-js": "gulp clean && gulp build-js",
+    "build": "gulp build",
     "upload": "env NODE_ENV=production gulp upload"
   },
   "repository": {


### PR DESCRIPTION
This simplifies the build process and ensures that new versions of assets will
be available before someone could try to use them through the new version
of the npm module. This change also means that assets will be published to
npm, but that’s not a bad thing, maybe a good thing even.