### PR TITLE
Use travis-org badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mixmax JS SDK
 
-[![Build Status](https://travis-ci.com/mixmaxhq/mixmax-sdk-js.svg?token=TcwK43uDe2DuFv6zy5Kb&branch=master)](https://travis-ci.com/mixmaxhq/mixmax-sdk-js)
+[![Build Status](https://travis-ci.org/mixmaxhq/mixmax-sdk-js.svg?branch=master)](https://travis-ci.org/mixmaxhq/mixmax-sdk-js)
 
 This repo is for our Mixmax JavaScript SDK for use by third party apps as well as Mixmax's own apps.
 It exports a top level module called `Mixmax`, with submodules


### PR DESCRIPTION
I'm assuming this was a private repo that we made public - this means travis will only build this on https://travis-ci.org instead of https://travis-ci.com.

We'll need to wait until we actually release a new version before merging this, as the badge hasn't been updated.