### PR TITLE
[ST-786] - Use assets in production for local development

### DIFF
--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -15,16 +15,12 @@ class Environment {
   }
 
   get assetsUrl() {
-    if (this.is(Environment.PRODUCTION)) {
-      return `https://sdk.mixmax.com/v${this.version}`;
-    } else {
-      return 'http://localhost:9000/dist';
-    }
+    // Edit source to toggle local vs. production assets.
+    return `https://sdk.mixmax.com/v${this.version}`;
   }
 
   get composeUrl() {
-    // Not sure how to toggle a local vs. production environment.
-    // Will leave it to the developer to temporarily edit the source for now.
+    // Edit source to toggle local vs. production compose.
     return 'https://compose.mixmax.com';
   }
 


### PR DESCRIPTION
Resolves: [ST-786](https://mixmaxhq.atlassian.net/browse/ST-786)

According to our [documentation](https://github.com/mixmaxhq/mixmax-sdk-js/blob/master/CONTRIBUTING.md#running-locally): 

```
Developers can edit source to point to the local domains instead.
```

Having said that, we do not need to perform checks on code to detect `local` vs `production` to retrieve assets, etc.

For context: https://github.com/mixmaxhq/mixmax-sdk-js/pull/28#issuecomment-497037767 

