### PR TITLE
fix: load embedded calendar when page is partially loaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mixmaxhq/sdk",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Our client-side SDK.",
   "main": "dist/Mixmax.umd.js",
   "module": "dist/Mixmax.es.js",

--- a/src/widgets.js
+++ b/src/widgets.js
@@ -22,8 +22,12 @@ const loadCSS = once(() => {
 
 const documentReady = once(() => {
   return new Promise((resolve) => {
-    if (document.readyState === 'complete') resolve();
-    else window.addEventListener('DOMContentLoaded', resolve);
+    const domContentAlreadyTriggered = document.readyState === 'interactive' || document.readyState === 'complete';
+    if (domContentAlreadyTriggered) {
+      resolve();
+    } else {
+      window.addEventListener('DOMContentLoaded', resolve);
+    }
   });
 });
 


### PR DESCRIPTION
#### Changes Made
Fixes https://mixmaxhq.atlassian.net/browse/SUP-2850. In debugging the Mixmax embedded calendar not loading on site www.edisonbio.com/thankyouforsubscribing, I realized that the document.readyState at the time our load function was called is 'interactive'. Yet the DOMContentLoaded event was already fired.

According to https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState, if the readyState is 'interactive' OR 'complete', we can assume `DOMContentLoaded` was already fired or is just about to be.

#### Potential Risks
That this is too early and the code won't be able to load. However I don't think this is the case based on the documentation.

#### Test Plan
- [x] Run `npm start` in this repo. Open https://sdk-local.mixmax.com/examples/embeddedcalendar/index.html and ensure the calendar loads.

#### Release
- [ ] Deploy via `npm update`
- [ ] Update where we reference it in the product https://github.com/mixmaxhq/app/blob/d3cea87e116293df27a78c4c0dcd975c6c9b4e8b/src/client/js/views/dashboard/meetingtemplates/editor/CalendarSharing.jsx#L13