### PR TITLE
fix: local development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,13 +1,8 @@
 ## Running locally
 
-1. Add the following entry to your `/etc/hosts/` file (Mixmax internal note: this is already added by `mixmax-runner`):
-```
-127.0.0.1 sdk-local.mixmax.com
-```
+1. Run `npm start` to build the JS and run the web server locally
 
-2. Run `npm start` to build the JS and run the web server locally
-
-3. Load https://sdk-local.mixmax.com/examples/embeddedcalendar/index.html. You should see the embedded calendar loading.
+2. Load https://sdk-local.mixmax.com/examples/embeddedcalendar/index.html. You should see the embedded calendar loading.
 
 Note that _locally_ means your local mixmax-sdk-js server, but embedded calendars and sequence pickers
 will point to their production domains. Mixmax internal note: edit
@@ -46,6 +41,7 @@ that reference a particular version of the SDK so that users will know to instal
 version:
 
 * The "Share your link" flyout in meeting types, which shares code for calendar embeeding
+* Developer documention page https://developer.mixmax.com/docs/introduction-widget-sdk
 
 ^ We should automate this in the future, perhaps by fetching the latest, acceptable SDK version
 from an API.

--- a/examples/embeddedcalendar/index.html
+++ b/examples/embeddedcalendar/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Embedded Calendar</title>
-    <script defer src="http://localhost:9000/dist/widgets.umd.js"></script>
+    <script defer src="http://localhost:64969/dist/widgets.umd.js"></script>
   </head>
   <body>
     <div style="margin: 0 auto; width: 800px;">

--- a/examples/sequencepicker/index.html
+++ b/examples/sequencepicker/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Sequence Picker</title>
-    <script defer src="http://localhost:9000/dist/widgets.umd.js"></script>
+    <script defer src="http://localhost:64969/dist/widgets.umd.js"></script>
   </head>
   <body>
     <table>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -201,7 +201,11 @@ gulp.task('webserver', function() {
   ws = gulp.src('.')
     .pipe(webserver({
       directoryListing: true,
-      port: 9000
+      // Pick an uncommon port number that local developers won't be using. If they happen to be
+      // using the production Mixmax SDK and developing something else locally on this port, then
+      // our environment check in Environment.js will think the SDK is running locally and it
+      // won't work.
+      port: 64969 // MIXMX on a T9 keypad ;)
     }));
 });
 

--- a/src/utils/Environment.js
+++ b/src/utils/Environment.js
@@ -1,7 +1,10 @@
 class Environment {
   get() {
-    if (window.location.hostname === 'sdk-local.mixmax.com') return Environment.LOCAL;
-    else return Environment.PRODUCTION;
+    if (window.location.origin === 'http://localhost:64969') {
+      return Environment.LOCAL;
+    } else {
+      return Environment.PRODUCTION;
+    }
   }
 
   is(env) {
@@ -16,7 +19,7 @@ class Environment {
 
   get assetsUrl() {
     if (this.is(Environment.LOCAL)) {
-      return 'http://localhost:9000/dist';
+      return 'http://localhost:64969/dist';
     } else {
       return `https://sdk.mixmax.com/v${this.version}`;
     }


### PR DESCRIPTION
#### Changes Made
After submitting PR https://github.com/mixmaxhq/mixmax-sdk-js/pull/39 I realized that the solution to use sdk-local.mixmax.com as the local environment check won't work for third party developers. Only Mixmax engineers have access to the service (mixmax-runner) that proxies sdk-local.mixmax.com to localhost:9000. The /etc/hosts file cannot redirect an HTTPS query to a local port.

This simplifies the local check by going back to using localhost. However, unlike before, we're now checking to ensure it's loaded from a specific port. I chose a unique port number since if a developer was using this same port and using the production version of the Mixmax SDK, the SDK's internal environment check would think that it's running locally and it wouldn't load properly.

Ideally in the future we'd implement a more robust environment by having the local webserver (run by gulp-webserver) pass some information down to the Environment.js to tell it that it's running locally. For now, I think checking that it's running on localhost:64969 will suffice.

#### Potential Risks
See above - that developers developing locally on localhost:64969 with the production Mixmax SDK will not be able to load it. I think this is extremely unlikely and not worth solving for now.

#### Test Plan
- [ ] Run `npm run start`. Go to http://localhost:64969/examples/sequencepicker/index.html and http://localhost:64969/examples/embeddedcalendar/index.html. Both should load the SDK.

#### Checklist
- [X] I've increased test coverage
- [X] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.

Deploy:
- [ ] Merge this
- [ ] Publish it
- [ ] Remove sdk-local.mixmax.com from other Mixmax repos, as we can no longer use it.