### PR TITLE
docs: deploy instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,15 +31,15 @@ Note that certain targets may be disabled pending browser support; see [here](ht
 
 ## Deployment (for Mixmax engineers)
 
-Run [`npm-publish`](https://github.com/mixmaxhq/mixmax-runner/blob/master/scripts/npm-publish)
-_with the `--no-publish` flag_.
-
-Travis will respond to the new tag being pushed to the remote by building the
-SDK and publishing the new version of the package to npm as well as to the CDN.
+1. Run `npm version <next version string>`
+2. Update CHANGELOG.md and commit
+3. Run `git push --follow-tags`
+4. Run `npm publish`
+5. Run `npm run upload`
 
 CDN releases will be scoped under the directory `/v${VERSION}`. For instance,
-if you just released version 1.2.1, the overall UMD bundle will be available at
-https://sdk.mixmax.com/v1.2.1/Mixmax.umd.js.
+if you just released version 2.0.6, the overall UMD bundle will be available at
+https://sdk.mixmax.com/v2.0.0/widgets.umd.min.js.
 
 After you release a new version of the SDK, please update the following locations in the product
 that reference a particular version of the SDK so that users will know to install the newer


### PR DESCRIPTION
#### Changes Made
At one time we had TravisCI set up to automatically deploy the SDK. Something has since broken and I don't have time to debug it. We want to move off Travis anyways. So I think it's better for us to "manually" deploy using these steps.

Also, the former instructions referenced the `npm-publish` script that's no longer available.

#### Potential Risks
Low. I ran through these instructions to publish 2.0.6 locally (and pushed to master). This assumes engineers will have an AWS key with access to publish (see test plan).

#### Test Plan
- [ ] Run `npm run upload`. This is the only part of the deploy plan that's safe to run w/o actually publishing a new version. This should be safe since it'll upload the same version. It should say `[skip]` for all files, indicating that it did not update the files. If it doesn't, let me know!
![image](https://user-images.githubusercontent.com/821706/107248610-75925280-6a00-11eb-972d-d4b3af253149.png)

#### Checklist
- [ ] I've increased test coverage
- [ ] Since this is a public repository, I've checked I'm not publishing private data in the code, commit comments, or this PR.
