### PR TITLE
Sidebar SDK fixes

### DIFF
--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -19,7 +19,13 @@ class Sidebar extends EventEmitter {
       });
     });
 
-    Host.on('contactSelected', (contact) => this.emit('contactSelected', contact));
+    Host.on('heartbeat', () => {
+      Host.send('heartbeat');
+    });
+
+    Host.on('contactSelected', (contact) =>
+      this.emit('contactSelected', contact)
+    );
 
     Host.on('clear', () => this.emit('clear'));
   }

--- a/src/sidebar.js
+++ b/src/sidebar.js
@@ -11,14 +11,6 @@ class Sidebar extends EventEmitter {
   constructor() {
     super();
 
-    Host.on('beforeContactSelected', () => {
-      const e = new Event();
-      this.emit('beforeContactSelected', e);
-      Host.send('ackBeforeContactSelected', {
-        isDefaultPrevented: e.isDefaultPrevented
-      });
-    });
-
     Host.on('heartbeat', () => {
       Host.send('heartbeat');
     });


### PR DESCRIPTION
Jira: https://mixmaxhq.atlassian.net/browse/SUP-3668

#### Changes Made
Removes security layer that restricts sending messages to an expected origin URL (that hosts the iframe). I couldn't find where we ever sent a 'setOrigin' message: https://hound.mixmax.com/?q=setOrigin&i=fosho&files=&excludeFiles=&repos=. This didn't provide much security anyways, as a malicious app could iframe a custom sidebar and send 'setOrigin' with its own origin.

Removes dead code `beforeContactSelected`. This event was never sent to the iframe, or it was removed many years ago. See [this code search](https://hound.mixmax.com/?q=beforeContactSelected&i=fosho&files=&excludeFiles=&repos=).

Responds to the 'heartbeat' event. If sidebars fail to send this then we [automatically refresh them](https://github.com/mixmaxhq/app/blob/1117dd01c8457d6ca4ad9c9025070eff6dbaa7a0/src/client/js/views/sidebar/people/PeopleIFrameView.js#L32). This code was added in https://mixmaxhq.atlassian.net/browse/MX-1470 but we missed adding it to our Sidebar SDK.

#### Potential Risks
See above.

#### Test Plan
1. Set up a local https website (eg https://app-local.mixmax.com/test.html) with the HTML `<script src="http://localhost:9000/dist/sidebar.umd.js"></script>`.
2. Add it as a custom sidebar in https://app.mixmax.com/dashboard/settings/personal/developer
3. Refresh Gmail and open the custom sidebar

It should not refresh every 30sec.

#### Deploy
- [ ] Instructions in https://github.com/mixmaxhq/mixmax-sdk-js/blob/master/CONTRIBUTING.md